### PR TITLE
fix dynamic library loading for macos arm64 platform.

### DIFF
--- a/local_editor/scripts/build-web-page-macos.sh
+++ b/local_editor/scripts/build-web-page-macos.sh
@@ -30,6 +30,7 @@ popd
 cp -r top/dist/assets dist/console/
 cp -r top/dist/project dist/console/
 cp -r local_editor/resource/docs dist/console/
+cp common/favicon.ico dist/console/
 rm -rf dist/console/lib/dummy
 popd
 

--- a/local_editor/scripts/build_mac_applesilicon.sh
+++ b/local_editor/scripts/build_mac_applesilicon.sh
@@ -85,22 +85,20 @@ cp -rf local_editor/runner_component/tools/nncd_console electron_app/py/connecto
 cp -rf ~/.anyenv/envs/pyenv/versions/3.10.14 electron_app/python_bundles
 
 # # copy lib
-cp -P /opt/homebrew/Cellar/gettext/0.22.5/lib/libintl.8.dylib electron_app/python_bundles/bin/ || exit 1
-cp -P /opt/homebrew/Cellar/openssl@3/3.3.0/lib/libssl.3.dylib electron_app/python_bundles/lib/python3.10/lib-dynload/ || exit 1
-cp -P /opt/homebrew/Cellar/openssl@3/3.3.0/lib/libcrypto.3.dylib electron_app/python_bundles/lib/python3.10/lib-dynload/ || exit 1
+libs=(
+  "/opt/homebrew/lib/libintl.8.dylib"
+  "/opt/homebrew/lib/libssl.3.dylib"
+  "/opt/homebrew/lib/libcrypto.3.dylib"
+  "/opt/homebrew/opt/readline/lib/libreadline.8.dylib"
+  "/opt/homebrew/opt/ncurses/lib/libncursesw.6.dylib"
+  "/opt/homebrew/opt/ncurses/lib/libpanelw.6.dylib"
+  "/opt/homebrew/opt/xz/lib/liblzma.5.dylib"
+)
 
-install_name_tool \
-    -change /opt/homebrew/lib/libintl.8.dylib "@executable_path/libintl.8.dylib" \
-    electron_app/python_bundles/bin/python3 || exit 1
-install_name_tool \
-    -change /opt/homebrew/lib/libssl.3.dylib "@loader_path/libssl.3.dylib" \
-    electron_app/python_bundles/lib/python3.10/lib-dynload/_ssl.cpython-310-darwin.so || exit 1
-install_name_tool \
-    -change /opt/homebrew/lib/libcrypto.3.dylib "@loader_path/libcrypto.3.dylib" \
-    electron_app/python_bundles/lib/python3.10/lib-dynload/_ssl.cpython-310-darwin.so || exit 1
-install_name_tool \
-    -change /opt/homebrew/Cellar/openssl@3/3.3.0/lib/libcrypto.3.dylib "@loader_path/libcrypto.3.dylib" \
-    electron_app/python_bundles/lib/python3.10/lib-dynload/libssl.3.dylib || exit 1
+for lib in "${libs[@]}"; do
+  cp -L "$lib" electron_app/python_bundles/lib/ || exit 1
+done
+
 
 # # pip install
 electron_app/python_bundles/bin/python3.10 -m pip install --upgrade pip || exit 1

--- a/local_editor/web_component/local_editor_web/package.json
+++ b/local_editor/web_component/local_editor_web/package.json
@@ -10,7 +10,7 @@
     "copy-html": "cp ./src/*.html ../dist/console/",
     "copy-image": "cp -r ./src/image ../dist/console",
     "copy-css": "cp -r ./src/css ../dist/console && cp ./node_modules/sweetalert2/dist/sweetalert2.min.css ../dist/console/lib/css/ && cp ./node_modules/vue2-timepicker/dist/VueTimepicker.css ../dist/console/lib/css/",
-    "copy-browser": "cp -r ./src/browser/ ../dist/console",
+    "copy-browser": "cp -r ./src/browser ../dist/console",
     "copy-project-converter-js": "cp ../new_editor/shared_scripts/ProjectConverter.js ../dist/console/js/",
     "copy-empty-configuration-js": "cp ../new_editor/shared_scripts/EmptyConfiguration.js ../dist/console/js/",
     "copy-nnabla-corelib-defs-js": "cp ../new_editor/shared_scripts/nnabla-corelib-defs.js ../dist/console/js/",


### PR DESCRIPTION
The dynamic library loading failure was reported: https://github.com/sony/nnc-desktop/issues/5
This is because lib and code signature had been broken by `install_name_tool`, so we use `DYLD_LIBRARY_PATH` instead.