### PR TITLE
remove to use TMPDIR for dataset cache

### DIFF
--- a/local_editor/python_modules/core/dataset/delete_dataset.py
+++ b/local_editor/python_modules/core/dataset/delete_dataset.py
@@ -44,7 +44,7 @@ def delete_dataset(user_id: str, dataset_id: int):
     # remove dataset files
     file_path_list = [
         os.path.join(settings.DATASETS_DIR, str(dataset.tenant_id), str(dataset_id)),
-        os.path.join(settings.DATASET_CACHE_DIR, str(dataset.tenant_id), str(dataset_id))
+        os.path.join(settings.DATASET_CACHE_DIR, str(dataset.tenant_id), f"{dataset_id}.cache")
     ]
     for file_path in file_path_list:
         if os.path.exists(file_path):

--- a/local_editor/python_modules/core/dataset/upload_dataset.py
+++ b/local_editor/python_modules/core/dataset/upload_dataset.py
@@ -76,11 +76,10 @@ def upload_dataset(user_id: str):
 
 
 def prepare_dataset_stock(tenant_id: str, dataset_id: int, filepath: str) -> str:
-    for path in [settings.DATASET_CACHE_DIR, settings.DATASETS_DIR]:
-        dir_path = os.path.join(path, tenant_id, str(dataset_id))
-        os.makedirs(dir_path, exist_ok=True)
+    dir_path = os.path.join(settings.DATASETS_DIR, tenant_id, str(dataset_id))
+    os.makedirs(dir_path, exist_ok=True)
         
-    stockfile = os.path.join(settings.DATASETS_DIR, tenant_id, str(dataset_id), "index.csv")
+    stockfile = os.path.join(dir_path, "index.csv")
 
     format_stock_file(filepath, stockfile)
     

--- a/local_editor/runner_component/core/upload_dataset/main.py
+++ b/local_editor/runner_component/core/upload_dataset/main.py
@@ -68,8 +68,9 @@ def _get_folder_size(folder_path: str, size=0):
 class ConvertStatus:
 
     def __init__(self, destination: str):
+        dest = destination.replace('.cache', '')
 
-        paths = destination.split(os.sep)
+        paths = dest.split(os.sep)
         self.tenant_id = paths[-2]
         self.dataset_id = paths[-1]
 
@@ -334,7 +335,7 @@ def main(argv: list):
                 "Not `dataset_id` or `tenant_id` arg.", Code.E_NNCD_ARGS_ERROR
             )
 
-        cache_dir = os.path.join(consts.CACHE_DIR_NAME, tenant_id, str(dataset_id))
+        cache_dir = os.path.join(consts.CACHE_DIR_NAME, tenant_id, f"{dataset_id}.cache")
 
         # init status
         status = init_status(cache_dir, index_file_path)

--- a/local_editor/scripts/build_mac_applesilicon.sh
+++ b/local_editor/scripts/build_mac_applesilicon.sh
@@ -93,6 +93,7 @@ libs=(
   "/opt/homebrew/opt/ncurses/lib/libncursesw.6.dylib"
   "/opt/homebrew/opt/ncurses/lib/libpanelw.6.dylib"
   "/opt/homebrew/opt/xz/lib/liblzma.5.dylib"
+  "/opt/homebrew/opt/sqlite/lib/libsqlite3.dylib"
 )
 
 for lib in "${libs[@]}"; do


### PR DESCRIPTION
This PR would like to fix https://github.com/sony/nnc-desktop/issues/11.

This issue seems to be happened on Mac environment only because other processes are deleting files in temporary directory.
This PR changes the dataset cache path to use the dataset path instead of TMPDIR.
